### PR TITLE
Prioritize H2 via ALPN.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ hex = "0.4.3"
 nom = "8.0.0"
 
 tokio-rustls = { version = "0.26", default-features = false }
+rustls-pemfile = "2.0"
 futures-util = { version = "0.3.31", default-features = false }
 httlib-hpack = "0.1.3"
 pin-project-lite = "0.2.9"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -32,7 +32,7 @@ impl Daemon {
     /// Get the pid of the daemon
     fn get_pid(&self) -> crate::Result<Option<String>> {
         if let Ok(data) = std::fs::read(&self.pid_file) {
-            let binding = String::from_utf8(data)?;
+            let binding = String::from_utf8(data).unwrap();
             return Ok(Some(binding.trim().to_string()));
         }
         Ok(None)

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,6 @@ pub enum Error {
     #[error(transparent)]
     Join(#[from] tokio::task::JoinError),
 
-    #[error(transparent)]
-    Utf8(#[from] std::string::FromUtf8Error),
+    #[error("{0}")]
+    Other(String),
 }


### PR DESCRIPTION
I set ALPN on the rustls config so the server actually advertises "h2". Without that, browsers were sticking to HTTP/1.1 even though .http2() was enabled. Switching from the self-signed cert to Let’s Encrypt made it obvious ALPN wasn’t set, so HTTP/2 never negotiated. This fixes it by explicitly advertising h2, with fallbacks to HTTP/1.1, then 1.0, then 0.9 for odd clients.

I changed the error handling to get this in. It would be better to add a dedicated error for ALPN/TLS config (see src/error.rs lines 36–37) instead of the generic path I used but i don't really know what to set.

Also, if you add h3 or httpbis later it would be nice to have a way to change the HTTP versions priorities.