### PR TITLE
TCP/IP Analysis support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ bytes = "1.9.0"
 md5 = "0.8.0"
 hex = "0.4.3"
 nom = "8.0.0"
+pcap = "2.0"
+pnet = "0.35"
 
 tokio-rustls = { version = "0.26", default-features = false }
 rustls-pemfile = "2.0"
@@ -58,7 +60,7 @@ mimalloc = { version = "0.1.39", default-features = false, optional = true }
 [target.'cfg(target_family = "unix")'.dependencies]
 daemonize = "0.5.0"
 nix = { version = "0.30.1", features = ["user", "signal"] }
-sysinfo = { version = "0.37", default-features = false, features = ["system"] }
+sysinfo = "0.30"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ hex = "0.4.3"
 nom = "8.0.0"
 pcap = "2.0"
 pnet = "0.35"
+serde_json = "1.0"
 
 tokio-rustls = { version = "0.26", default-features = false }
 rustls-pemfile = "2.0"
@@ -49,6 +50,7 @@ httlib-hpack = "0.1.3"
 pin-project-lite = "0.2.9"
 tls-parser = "0.12.0"
 httparse = "1.8.0"
+pktparse = { version = "0.7.1", features = ["serde"] }
 boxcar = "0.2.8"
 
 tcmalloc = { version = "0.3.0", optional = true }

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -1,0 +1,287 @@
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+    time::{SystemTime, UNIX_EPOCH},
+};
+use serde::{Deserialize, Serialize};
+use tokio::task;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapturedPacket {
+    pub timestamp: u64,
+    pub direction: String, // "inbound" or "outbound"
+    pub src_ip: String,
+    pub dst_ip: String,
+    pub src_port: u16,
+    pub dst_port: u16,
+    pub protocol: String, // "TCP", "UDP", etc.
+    pub payload_hex: String,
+    pub packet_size: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct PacketCapture {
+    packets: Arc<Mutex<VecDeque<CapturedPacket>>>,
+    max_packets: usize,
+    server_port: u16,
+}
+
+impl PacketCapture {
+    pub fn new(max_packets: usize, server_port: u16) -> Self {
+        Self {
+            packets: Arc::new(Mutex::new(VecDeque::new())),
+            max_packets,
+            server_port,
+        }
+    }
+
+    pub fn start_capture(&self, interface: Option<String>) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let packets = self.packets.clone();
+        let max_packets = self.max_packets;
+        let server_port = self.server_port;
+
+        tracing::info!("Attempting to start packet capture on port {}", server_port);
+
+        // Test basic pcap functionality first
+        match self.test_pcap_basic(interface.clone()) {
+            Ok(device_name) => {
+                tracing::info!("Packet capture test passed, using device: {}", device_name);
+
+                // Spawn the actual capture task
+                let capture_handle = tokio::task::spawn_blocking(move || {
+                    if let Err(e) = Self::run_capture_blocking(packets, max_packets, server_port, interface) {
+                        tracing::error!("Packet capture task error: {}", e);
+                    }
+                });
+
+                // Give the capture task a moment to initialize before returning
+                std::thread::sleep(std::time::Duration::from_millis(500));
+                tracing::info!("Packet capture background task started");
+
+                Ok(())
+            }
+            Err(e) => {
+                tracing::error!("Packet capture initialization failed: {}", e);
+                Err(e)
+            }
+        }
+    }
+
+    fn test_pcap_basic(&self, interface: Option<String>) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        use pcap::{Capture, Device};
+
+        let devices = Device::list()?;
+        tracing::info!("Available network devices:");
+        for (i, device) in devices.iter().enumerate() {
+            tracing::info!("  {}: {} ({})", i, device.name, device.desc.as_ref().unwrap_or(&"No description".to_string()));
+        }
+
+        let device = if let Some(iface) = interface {
+            devices
+                .into_iter()
+                .find(|d| d.name == iface)
+                .ok_or(format!("Interface {} not found", iface))?
+        } else {
+            // For localhost testing, prefer loopback interface over 'any'
+            devices.iter()
+                .find(|d| d.name == "lo")
+                .cloned()
+                .or_else(|| devices.iter().find(|d| d.name == "any").cloned())
+                .unwrap_or_else(|| devices.into_iter().next().unwrap())
+        };
+
+        let use_promisc = device.name != "any";
+        let _test_cap = Capture::from_device(device.clone())?
+            .promisc(use_promisc)
+            .snaplen(1500)
+            .timeout(100)
+            .open()?;
+
+        Ok(device.name)
+    }
+
+    fn run_capture_blocking(
+        packets: Arc<Mutex<VecDeque<CapturedPacket>>>,
+        max_packets: usize,
+        server_port: u16,
+        interface: Option<String>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        use pcap::{Capture, Device};
+        use pnet::packet::{
+            ethernet::{EtherTypes, EthernetPacket},
+            ip::IpNextHeaderProtocols,
+            ipv4::Ipv4Packet,
+            ipv6::Ipv6Packet,
+            tcp::TcpPacket,
+            Packet,
+        };
+
+        let devices = Device::list()?;
+        let device = if let Some(iface) = interface {
+            devices
+                .into_iter()
+                .find(|d| d.name == iface)
+                .ok_or(format!("Interface {} not found", iface))?
+        } else {
+            devices.iter()
+                .find(|d| d.name == "lo")
+                .cloned()
+                .or_else(|| devices.iter().find(|d| d.name == "any").cloned())
+                .unwrap_or_else(|| devices.into_iter().next().unwrap())
+        };
+
+        tracing::info!("Starting packet capture on interface: {}", device.name);
+
+        let use_promisc = device.name != "any";
+        let mut cap = Capture::from_device(device)?
+            .promisc(use_promisc)
+            .snaplen(65535)
+            .timeout(100)
+            .open()?;
+
+        let filter = format!("tcp and dst port {}", server_port);
+        tracing::info!("Setting packet filter: {}", filter);
+        cap.filter(&filter, true)?;
+
+        tracing::info!("Packet capture loop started, waiting for packets...");
+        let mut packet_count = 0;
+
+        loop {
+            match cap.next_packet() {
+                Ok(packet) => {
+                    packet_count += 1;
+                    tracing::info!("Raw packet #{} captured, size: {} bytes", packet_count, packet.data.len());
+
+                    if let Some(captured_packet) = Self::parse_packet(&packet.data, server_port) {
+                        let mut packets_guard = packets.lock().unwrap();
+
+                        if packets_guard.len() >= max_packets {
+                            packets_guard.pop_front();
+                        }
+
+                        packets_guard.push_back(captured_packet.clone());
+                        tracing::info!("Captured packet #{}: {} -> {} ({})",
+                            packet_count,
+                            captured_packet.src_ip,
+                            captured_packet.dst_ip,
+                            captured_packet.direction
+                        );
+                    } else {
+                        let raw_packet = CapturedPacket {
+                            timestamp: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64,
+                            direction: "unknown".to_string(),
+                            src_ip: "unknown".to_string(),
+                            dst_ip: "unknown".to_string(),
+                            src_port: 0,
+                            dst_port: server_port,
+                            protocol: "RAW".to_string(),
+                            payload_hex: hex::encode(&packet.data),
+                            packet_size: packet.data.len(),
+                        };
+
+                        let mut packets_guard = packets.lock().unwrap();
+                        if packets_guard.len() >= max_packets {
+                            packets_guard.pop_front();
+                        }
+                        packets_guard.push_back(raw_packet);
+
+                        tracing::warn!("Stored raw packet #{} (parsing failed)", packet_count);
+                    }
+                }
+                Err(pcap::Error::TimeoutExpired) => {
+                    // Timeout is normal, continue
+                    continue;
+                }
+                Err(e) => {
+                    tracing::error!("Packet capture error: {}", e);
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                }
+            }
+        }
+    }
+
+    fn parse_packet(data: &[u8], server_port: u16) -> Option<CapturedPacket> {
+        use pnet::packet::{
+            ethernet::{EtherTypes, EthernetPacket},
+            ip::IpNextHeaderProtocols,
+            ipv4::Ipv4Packet,
+            ipv6::Ipv6Packet,
+            tcp::TcpPacket,
+            Packet,
+        };
+
+        let ethernet = EthernetPacket::new(data)?;
+
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+
+        match ethernet.get_ethertype() {
+            EtherTypes::Ipv4 => {
+                let ipv4 = Ipv4Packet::new(ethernet.payload())?;
+
+                if ipv4.get_next_level_protocol() == IpNextHeaderProtocols::Tcp {
+                    let tcp = TcpPacket::new(ipv4.payload())?;
+                    let src_port = tcp.get_source();
+                    let dst_port = tcp.get_destination();
+
+                    if dst_port == server_port {
+                        return Some(CapturedPacket {
+                            timestamp,
+                            direction: "inbound".to_string(),
+                            src_ip: ipv4.get_source().to_string(),
+                            dst_ip: ipv4.get_destination().to_string(),
+                            src_port,
+                            dst_port,
+                            protocol: "TCP".to_string(),
+                            payload_hex: hex::encode(data),
+                            packet_size: data.len(),
+                        });
+                    }
+                }
+            }
+            EtherTypes::Ipv6 => {
+                let ipv6 = Ipv6Packet::new(ethernet.payload())?;
+
+                if ipv6.get_next_header() == IpNextHeaderProtocols::Tcp {
+                    let tcp = TcpPacket::new(ipv6.payload())?;
+                    let src_port = tcp.get_source();
+                    let dst_port = tcp.get_destination();
+
+                    if dst_port == server_port {
+                        return Some(CapturedPacket {
+                            timestamp,
+                            direction: "inbound".to_string(),
+                            src_ip: ipv6.get_source().to_string(),
+                            dst_ip: ipv6.get_destination().to_string(),
+                            src_port,
+                            dst_port,
+                            protocol: "TCP".to_string(),
+                            payload_hex: hex::encode(data),
+                            packet_size: data.len(),
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        None
+    }
+
+    pub fn get_packets(&self) -> Vec<CapturedPacket> {
+        let packets_guard = self.packets.lock().unwrap();
+        packets_guard.iter().cloned().collect()
+    }
+
+    pub fn clear_packets(&self) {
+        let mut packets_guard = self.packets.lock().unwrap();
+        packets_guard.clear();
+    }
+
+    pub fn get_packet_count(&self) -> usize {
+        let packets_guard = self.packets.lock().unwrap();
+        packets_guard.len()
+    }
+}

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -284,4 +284,26 @@ impl PacketCapture {
         let packets_guard = self.packets.lock().unwrap();
         packets_guard.len()
     }
+
+    pub fn get_packets_for_client(&self, client_ip: &str, client_port: u16) -> Vec<CapturedPacket> {
+        let packets_guard = self.packets.lock().unwrap();
+        packets_guard
+            .iter()
+            .filter(|packet| packet.src_ip == client_ip && packet.src_port == client_port)
+            .cloned()
+            .collect()
+    }
+
+    pub fn clear_packets_for_client(&self, client_ip: &str, client_port: u16) {
+        let mut packets_guard = self.packets.lock().unwrap();
+        packets_guard.retain(|packet| !(packet.src_ip == client_ip && packet.src_port == client_port));
+    }
+
+    pub fn get_packet_count_for_client(&self, client_ip: &str, client_port: u16) -> usize {
+        let packets_guard = self.packets.lock().unwrap();
+        packets_guard
+            .iter()
+            .filter(|packet| packet.src_ip == client_ip && packet.src_port == client_port)
+            .count()
+    }
 }

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -1,22 +1,24 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use std::{
     collections::VecDeque,
     sync::{Arc, Mutex},
     time::{SystemTime, UNIX_EPOCH},
 };
-use serde::{Deserialize, Serialize};
 use tokio::task;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CapturedPacket {
     pub timestamp: u64,
-    pub direction: String, // "inbound" or "outbound"
+    pub direction: String,
     pub src_ip: String,
     pub dst_ip: String,
     pub src_port: u16,
     pub dst_port: u16,
-    pub protocol: String, // "TCP", "UDP", etc.
+    pub protocol: String,
     pub payload_hex: String,
     pub packet_size: usize,
+    pub parsed_info: Option<JsonValue>,
 }
 
 #[derive(Debug, Clone)]
@@ -35,7 +37,10 @@ impl PacketCapture {
         }
     }
 
-    pub fn start_capture(&self, interface: Option<String>) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    pub fn start_capture(
+        &self,
+        interface: Option<String>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let packets = self.packets.clone();
         let max_packets = self.max_packets;
         let server_port = self.server_port;
@@ -48,8 +53,10 @@ impl PacketCapture {
                 tracing::info!("Packet capture test passed, using device: {}", device_name);
 
                 // Spawn the actual capture task
-                let capture_handle = tokio::task::spawn_blocking(move || {
-                    if let Err(e) = Self::run_capture_blocking(packets, max_packets, server_port, interface) {
+                let _capture_handle = tokio::task::spawn_blocking(move || {
+                    if let Err(e) =
+                        Self::run_capture_blocking(packets, max_packets, server_port, interface)
+                    {
                         tracing::error!("Packet capture task error: {}", e);
                     }
                 });
@@ -67,13 +74,24 @@ impl PacketCapture {
         }
     }
 
-    fn test_pcap_basic(&self, interface: Option<String>) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    fn test_pcap_basic(
+        &self,
+        interface: Option<String>,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         use pcap::{Capture, Device};
 
         let devices = Device::list()?;
         tracing::info!("Available network devices:");
         for (i, device) in devices.iter().enumerate() {
-            tracing::info!("  {}: {} ({})", i, device.name, device.desc.as_ref().unwrap_or(&"No description".to_string()));
+            tracing::info!(
+                "  {}: {} ({})",
+                i,
+                device.name,
+                device
+                    .desc
+                    .as_ref()
+                    .unwrap_or(&"No description".to_string())
+            );
         }
 
         let device = if let Some(iface) = interface {
@@ -83,7 +101,8 @@ impl PacketCapture {
                 .ok_or(format!("Interface {} not found", iface))?
         } else {
             // For localhost testing, prefer loopback interface over 'any'
-            devices.iter()
+            devices
+                .iter()
                 .find(|d| d.name == "lo")
                 .cloned()
                 .or_else(|| devices.iter().find(|d| d.name == "any").cloned())
@@ -123,7 +142,8 @@ impl PacketCapture {
                 .find(|d| d.name == iface)
                 .ok_or(format!("Interface {} not found", iface))?
         } else {
-            devices.iter()
+            devices
+                .iter()
                 .find(|d| d.name == "lo")
                 .cloned()
                 .or_else(|| devices.iter().find(|d| d.name == "any").cloned())
@@ -150,7 +170,11 @@ impl PacketCapture {
             match cap.next_packet() {
                 Ok(packet) => {
                     packet_count += 1;
-                    tracing::info!("Raw packet #{} captured, size: {} bytes", packet_count, packet.data.len());
+                    tracing::info!(
+                        "Raw packet #{} captured, size: {} bytes",
+                        packet_count,
+                        packet.data.len()
+                    );
 
                     if let Some(captured_packet) = Self::parse_packet(&packet.data, server_port) {
                         let mut packets_guard = packets.lock().unwrap();
@@ -160,15 +184,20 @@ impl PacketCapture {
                         }
 
                         packets_guard.push_back(captured_packet.clone());
-                        tracing::info!("Captured packet #{}: {} -> {} ({})",
+                        tracing::info!(
+                            "Captured packet #{}: {} -> {} ({})",
                             packet_count,
                             captured_packet.src_ip,
                             captured_packet.dst_ip,
                             captured_packet.direction
                         );
                     } else {
+                        let parsed_info = Self::parse_packet_with_pktparse(&packet.data);
                         let raw_packet = CapturedPacket {
-                            timestamp: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64,
+                            timestamp: SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .unwrap()
+                                .as_millis() as u64,
                             direction: "unknown".to_string(),
                             src_ip: "unknown".to_string(),
                             dst_ip: "unknown".to_string(),
@@ -177,6 +206,7 @@ impl PacketCapture {
                             protocol: "RAW".to_string(),
                             payload_hex: hex::encode(&packet.data),
                             packet_size: packet.data.len(),
+                            parsed_info,
                         };
 
                         let mut packets_guard = packets.lock().unwrap();
@@ -217,6 +247,8 @@ impl PacketCapture {
             .unwrap()
             .as_millis() as u64;
 
+        let parsed_info = Self::parse_packet_with_pktparse(data);
+
         match ethernet.get_ethertype() {
             EtherTypes::Ipv4 => {
                 let ipv4 = Ipv4Packet::new(ethernet.payload())?;
@@ -237,6 +269,7 @@ impl PacketCapture {
                             protocol: "TCP".to_string(),
                             payload_hex: hex::encode(data),
                             packet_size: data.len(),
+                            parsed_info,
                         });
                     }
                 }
@@ -260,6 +293,7 @@ impl PacketCapture {
                             protocol: "TCP".to_string(),
                             payload_hex: hex::encode(data),
                             packet_size: data.len(),
+                            parsed_info,
                         });
                     }
                 }
@@ -268,6 +302,117 @@ impl PacketCapture {
         }
 
         None
+    }
+
+    fn parse_packet_with_pktparse(data: &[u8]) -> Option<JsonValue> {
+        use pktparse::{ethernet, ip::IPProtocol, ipv4, ipv6, tcp, udp};
+        use serde_json::{json, to_value};
+
+        // Try to parse the ethernet frame
+        match ethernet::parse_ethernet_frame(data) {
+            Ok((remaining, eth_frame)) => {
+                let mut parsed = json!({
+                    "ethernet": {
+                        "ethertype": to_value(&eth_frame.ethertype).unwrap_or_else(|_| json!("unknown"))
+                    }
+                });
+
+                // Parse IP layer
+                match eth_frame.ethertype {
+                    ethernet::EtherType::IPv4 => {
+                        if let Ok((tcp_udp_data, ipv4_hdr)) = ipv4::parse_ipv4_header(remaining) {
+                            parsed["ipv4"] = to_value(&ipv4_hdr).unwrap_or_else(
+                                |_| json!({"error": "Failed to serialize IPv4 header"}),
+                            );
+
+                            // Parse transport layer
+                            match ipv4_hdr.protocol {
+                                IPProtocol::TCP => {
+                                    if let Ok((payload, tcp_hdr)) =
+                                        tcp::parse_tcp_header(tcp_udp_data)
+                                    {
+                                        parsed["tcp"] = to_value(&tcp_hdr).unwrap_or_else(
+                                            |_| json!({"error": "Failed to serialize TCP header"}),
+                                        );
+
+                                        // If there's application data, include a preview
+                                        if !payload.is_empty() {
+                                            let preview_len = std::cmp::min(payload.len(), 64);
+                                            parsed["application_data"] = json!({
+                                                "length": payload.len(),
+                                                "preview_hex": hex::encode(&payload[..preview_len]),
+                                                "preview_ascii": payload[..preview_len].iter()
+                                                    .map(|&b| if b.is_ascii_graphic() || b == b' ' { b as char } else { '.' })
+                                                    .collect::<String>()
+                                            });
+                                        }
+                                    }
+                                }
+                                _ => {
+                                    parsed["unknown_transport"] = json!({
+                                        "protocol": to_value(&ipv4_hdr.protocol).unwrap_or_else(|_| json!("unknown")),
+                                        "data_length": tcp_udp_data.len()
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    ethernet::EtherType::IPv6 => {
+                        if let Ok((tcp_udp_data, ipv6_hdr)) = ipv6::parse_ipv6_header(remaining) {
+                            parsed["ipv6"] = to_value(&ipv6_hdr).unwrap_or_else(
+                                |_| json!({"error": "Failed to serialize IPv6 header"}),
+                            );
+
+                            // Parse transport layer for IPv6
+                            match ipv6_hdr.next_header {
+                                IPProtocol::TCP => {
+                                    if let Ok((payload, tcp_hdr)) =
+                                        tcp::parse_tcp_header(tcp_udp_data)
+                                    {
+                                        parsed["tcp"] = to_value(&tcp_hdr).unwrap_or_else(
+                                            |_| json!({"error": "Failed to serialize TCP header"}),
+                                        );
+
+                                        // If there's application data, include a preview
+                                        if !payload.is_empty() {
+                                            let preview_len = std::cmp::min(payload.len(), 64);
+                                            parsed["application_data"] = json!({
+                                                "length": payload.len(),
+                                                "preview_hex": hex::encode(&payload[..preview_len]),
+                                                "preview_ascii": payload[..preview_len].iter()
+                                                    .map(|&b| if b.is_ascii_graphic() || b == b' ' { b as char } else { '.' })
+                                                    .collect::<String>()
+                                            });
+                                        }
+                                    }
+                                }
+                                _ => {
+                                    parsed["unknown_transport"] = json!({
+                                        "protocol": to_value(&ipv6_hdr.next_header).unwrap_or_else(|_| json!("unknown")),
+                                        "data_length": tcp_udp_data.len()
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    _ => {
+                        parsed["unknown_protocol"] = json!({
+                            "ethertype": to_value(&eth_frame.ethertype).unwrap_or_else(|_| json!("unknown")),
+                            "data_length": remaining.len()
+                        });
+                    }
+                }
+
+                Some(parsed)
+            }
+            Err(_) => {
+                Some(json!({
+                    "parse_error": "Failed to parse ethernet frame",
+                    "raw_data_length": data.len(),
+                    "raw_data_preview": hex::encode(&data[..std::cmp::min(data.len(), 32)])
+                }))
+            }
+        }
     }
 
     pub fn get_packets(&self) -> Vec<CapturedPacket> {
@@ -296,7 +441,8 @@ impl PacketCapture {
 
     pub fn clear_packets_for_client(&self, client_ip: &str, client_port: u16) {
         let mut packets_guard = self.packets.lock().unwrap();
-        packets_guard.retain(|packet| !(packet.src_ip == client_ip && packet.src_port == client_port));
+        packets_guard
+            .retain(|packet| !(packet.src_ip == client_ip && packet.src_port == client_port));
     }
 
     pub fn get_packet_count_for_client(&self, client_ip: &str, client_port: u16) -> usize {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod alloc;
+mod capture;
 #[cfg(target_family = "unix")]
 mod daemon;
 mod error;
@@ -44,6 +45,14 @@ pub struct Args {
     /// TLS private key file path (EC/PKCS8/RSA)
     #[clap(short = 'K', long)]
     pub tls_key: Option<PathBuf>,
+
+    /// Enable packet capture for TCP/IP analysis (requires root privileges)
+    #[clap(long)]
+    pub capture_packets: bool,
+
+    /// Network interface to capture packets from (default: auto-detect)
+    #[clap(long)]
+    pub capture_interface: Option<String>,
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,12 @@ pub struct Args {
     pub tls_key: Option<PathBuf>,
 
     /// Enable packet capture for TCP/IP analysis (requires root privileges)
+    #[cfg(target_family = "unix")]
     #[clap(long)]
     pub capture_packets: bool,
 
     /// Network interface to capture packets from (default: auto-detect)
+    #[cfg(target_family = "unix")]
     #[clap(long)]
     pub capture_interface: Option<String>,
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -184,36 +184,34 @@ pub async fn http2_track(
 
 #[inline]
 pub async fn get_packets(
+    Extension(ConnectInfo(addr)): Extension<ConnectInfo<SocketAddr>>,
     Extension(capture): Extension<PacketCapture>,
 ) -> Result<ErasedJson> {
-    // Small delay to ensure any packets from this request are captured
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let packets = capture.get_packets();
+    let client_ip = addr.ip().to_string();
+    let client_port = addr.port();
 
-    // Clear packets after retrieving them so each request shows fresh data
-    capture.clear_packets();
+    let packets = capture.get_packets_for_client(&client_ip, client_port);
 
-    // TODO: only clear packet matching the current request (ip port) to avoid losing packets
-    // So if there are multiple requests, we can still see packets for each one
+    capture.clear_packets_for_client(&client_ip, client_port);
 
     Ok(ErasedJson::pretty(&packets))
 }
 
 #[inline]
 pub async fn get_packet_count(
+    Extension(ConnectInfo(addr)): Extension<ConnectInfo<SocketAddr>>,
     Extension(capture): Extension<PacketCapture>,
 ) -> Result<ErasedJson> {
-    // Small delay to ensure any packets from this request are captured
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let count = capture.get_packet_count();
+    let client_ip = addr.ip().to_string();
+    let client_port = addr.port();
 
-    // Clear packets after getting count so each request shows fresh data
-    capture.clear_packets();
+    let count = capture.get_packet_count_for_client(&client_ip, client_port);
 
-    // TODO: only clear packet matching the current request (ip port) to avoid losing packets
-    // So if there are multiple requests, we can still see packets for each one
+    capture.clear_packets_for_client(&client_ip, client_port);
 
     Ok(ErasedJson::pretty(count))
 }


### PR DESCRIPTION
So, the "best" solution I found was to retrieve the entire packet, but unfortunately, with libc, nix, or other crates, this isn't really possible except by listening to an interface or changing the HTTP server. So you have to run it as root with the `--capture-packets` argument, which also allows you to retrieve all TCP packets before the start of the HTTP protocol with the SYN ACK of the TCP handshake.

I didn't implement JA4T because I saw several methods for doing the fingerprint, so I'll leave that part to you.

There's the raw packet in the response with the information parsed like this, for example
<details>
<summary>Pingly response</summary>

<pre><code>
[
  {
    "timestamp": 1755726194073,
    "direction": "inbound",
    "src_ip": "127.0.0.1",
    "dst_ip": "127.0.0.1",
    "src_port": 57486,
    "dst_port": 8181,
    "protocol": "TCP",
    "payload_hex": "00000000000000000000000008004500003404bc4000400638067f0000017f000001e08e1ff531bb24caa762708d801003b6fe2800000101080a7e3e24ea7e3e24ea",
    "packet_size": 66,
    "parsed_info": {
      "ethernet": {
        "ethertype": "IPv4"
      },
      "ipv4": {
        "chksum": 14342,
        "dest_addr": "127.0.0.1",
        "flags": 2,
        "fragment_offset": 0,
        "id": 1212,
        "ihl": 5,
        "length": 52,
        "protocol": "TCP",
        "source_addr": "127.0.0.1",
        "tos": 0,
        "ttl": 64,
        "version": 4
      },
      "tcp": {
        "ack_no": 2808246413,
        "checksum": 65064,
        "data_offset": 8,
        "dest_port": 8181,
        "flag_ack": true,
        "flag_fin": false,
        "flag_psh": false,
        "flag_rst": false,
        "flag_syn": false,
        "flag_urg": false,
        "options": null,
        "reserved": 0,
        "sequence_no": 834348234,
        "source_port": 57486,
        "urgent_pointer": 0,
        "window": 950
      }
    }
  },
  {
    "timestamp": 1755726194073,
    "direction": "inbound",
    "src_ip": "127.0.0.1",
    "dst_ip": "127.0.0.1",
    "src_port": 57486,
    "dst_port": 8181,
    "protocol": "TCP",
    "payload_hex": "00000000000000000000000008004500003404bd4000400638057f0000017f000001e08e1ff531bb24caa7627ceb8010039efe2800000101080a7e3e24ea7e3e24ea",
    "packet_size": 66,
    "parsed_info": {
      "ethernet": {
        "ethertype": "IPv4"
      },
      "ipv4": {
        "chksum": 14341,
        "dest_addr": "127.0.0.1",
        "flags": 2,
        "fragment_offset": 0,
        "id": 1213,
        "ihl": 5,
        "length": 52,
        "protocol": "TCP",
        "source_addr": "127.0.0.1",
        "tos": 0,
        "ttl": 64,
        "version": 4
      },
      "tcp": {
        "ack_no": 2808249579,
        "checksum": 65064,
        "data_offset": 8,
        "dest_port": 8181,
        "flag_ack": true,
        "flag_fin": false,
        "flag_psh": false,
        "flag_rst": false,
        "flag_syn": false,
        "flag_urg": false,
        "options": null,
        "reserved": 0,
        "sequence_no": 834348234,
        "source_port": 57486,
        "urgent_pointer": 0,
        "window": 926
      }
    }
  },
  {
    "timestamp": 1755726194176,
    "direction": "inbound",
    "src_ip": "127.0.0.1",
    "dst_ip": "127.0.0.1",
    "src_port": 57486,
    "dst_port": 8181,
    "protocol": "TCP",
    "payload_hex": "00000000000000000000000008004500007604be4000400637c27f0000017f000001e08e1ff531bb24caa7627ceb801803b6fe6a00000101080a7e3e25437e3e24ea170303003dc1a984746d886c6d0fae7b25d7b2c190550adcc137fc9b65d085821c98dce28f7cbe4757f72dab95eb0ba62abcbca55dbb6061634220c2d4f7d7b999d0",
    "packet_size": 132,
    "parsed_info": {
      "application_data": {
        "length": 66,
        "preview_ascii": "....=...tm.lm..{%....U...7..e........|.GW.-.....*...].`acB .....",
        "preview_hex": "170303003dc1a984746d886c6d0fae7b25d7b2c190550adcc137fc9b65d085821c98dce28f7cbe4757f72dab95eb0ba62abcbca55dbb6061634220c2d4f7d7b9"
      },
      "ethernet": {
        "ethertype": "IPv4"
      },
      "ipv4": {
        "chksum": 14274,
        "dest_addr": "127.0.0.1",
        "flags": 2,
        "fragment_offset": 0,
        "id": 1214,
        "ihl": 5,
        "length": 118,
        "protocol": "TCP",
        "source_addr": "127.0.0.1",
        "tos": 0,
        "ttl": 64,
        "version": 4
      },
      "tcp": {
        "ack_no": 2808249579,
        "checksum": 65130,
        "data_offset": 8,
        "dest_port": 8181,
        "flag_ack": true,
        "flag_fin": false,
        "flag_psh": true,
        "flag_rst": false,
        "flag_syn": false,
        "flag_urg": false,
        "options": null,
        "reserved": 0,
        "sequence_no": 834348234,
        "source_port": 57486,
        "urgent_pointer": 0,
        "window": 950
      }
    }
  }
]
</code></pre>
</details>

I wasn't sure what to put as the patch for the request, so I put `/api/packets`, but maybe `/api/tcp` or `/api/tcp-ip` would be better.

_There was a problem with the sysinfo compilation for me, so I had to revert to 0.30 with the default features._