### PR TITLE
feat(tls): add display support for ML-DSA signature algorithms

### DIFF
--- a/src/server/tracker/inspector/tls/enums.rs
+++ b/src/server/tracker/inspector/tls/enums.rs
@@ -58,6 +58,9 @@ enum_builder! {
         ecdsa_brainpoolp256r1tls13_sha256 => 2074,
         ecdsa_brainpoolp384r1tls13_sha384 => 2075,
         ecdsa_brainpoolp512r1tls13_sha512 => 2076,
+        mldsa44 =>2308,
+        mldsa65 => 2309,
+        mldsa87 => 2310,
     }
 }
 


### PR DESCRIPTION
Starting from Google Chrome 150, the new ML-DSA (post-quantum) signature algorithm is supported: https://chromestatus.com/feature/5174590524489728, which means TLS fingerprints are about to be updated.