### PR TITLE
Exclude GREASE algorithms from signature algorithms

### DIFF
--- a/src/tls/ja4.rs
+++ b/src/tls/ja4.rs
@@ -53,7 +53,11 @@ impl Ja4Fingerprint {
                         .extend(data.versions.iter().map(|version| version.tls_version()));
                 }
                 TlsExtension::SignatureAlgorithms { data, .. } => {
-                    signature_algorithms.extend(data.iter().map(|algorithm| algorithm.value()));
+                    signature_algorithms.extend(
+                        data.iter()
+                            .filter(|algorithm| !algorithm.is_grease())
+                            .map(|algorithm| algorithm.value()),
+                    );
                 }
                 TlsExtension::ApplicationLayerProtocolNegotiation { data, .. }
                     if alpn.0.is_none() =>


### PR DESCRIPTION
Chrome 152 prepends a GREASE value to signature_algorithms (ahead of the new ML-DSA algorithms). Ciphers and extensions already filter GREASE before hashing, and SignatureAlgorithm even has its own is_grease(), it just wasn't called here, so the random GREASE value went straight into the JA4 hash instead of being stripped.