### PR TITLE
fix(h2): decode RST_STREAM frames and error codes

### DIFF
--- a/src/app/server/tracker/info.rs
+++ b/src/app/server/tracker/info.rs
@@ -807,7 +807,7 @@ fn http2_frame_ends_direction(frame: &Frame) -> bool {
 }
 
 fn http2_frame_resets_stream(frame: &Frame) -> bool {
-    matches!(frame, Frame::Unknown(frame) if frame.type_id == 0x03 && frame.length == 4)
+    matches!(frame, Frame::RstStream(_))
 }
 
 impl Http3TrackInfo {
@@ -1168,7 +1168,7 @@ mod tests {
         h2::{
             frame::{
                 DataFrame, HeaderField as Http2HeaderField, HeadersFlags,
-                HeadersFrame as Http2HeadersFrame, PriorityUpdateFrame,
+                HeadersFrame as Http2HeadersFrame, PriorityUpdateFrame, RstStreamFrame,
                 SettingsFrame as Http2SettingsFrame, StreamDependency,
                 UnknownFrame as Http2UnknownFrame, WindowUpdateFrame,
             },
@@ -1344,14 +1344,9 @@ mod tests {
         capture.push(Http2FrameEvent {
             elapsed_us: 40,
             direction: Http2FrameDirection::ServerToClient,
-            frame: Http2Frame::Unknown(Http2UnknownFrame {
-                frame_type: Http2FrameType::Unknown,
-                type_id: 0x03,
-                stream_id: 5,
-                length: 4,
-                flags: 0,
-                payload: vec![0; 4],
-            }),
+            frame: Http2Frame::RstStream(
+                RstStreamFrame::try_from((0, 5, &[0, 0, 0, 8][..])).unwrap(),
+            ),
         });
         capture.push(Http2FrameEvent {
             elapsed_us: 50,
@@ -1410,6 +1405,8 @@ mod tests {
         assert_eq!(value["sent_frames"][5]["type_id"], 6);
         assert_eq!(value["events"].as_array().unwrap().len(), 8);
         assert_eq!(value["events"][4]["direction"], "ServerToClient");
+        assert_eq!(value["events"][5]["frame_type"], "RstStream");
+        assert_eq!(value["events"][5]["error_code"]["name"], "Cancel");
         assert_eq!(stream["stream_id"], 3);
         assert_eq!(stream["method"], "GET");
         assert_eq!(stream["path"], "/api/http2");

--- a/src/app/server/ui/app.js
+++ b/src/app/server/ui/app.js
@@ -97,7 +97,6 @@ const CHROMIUM_PRIORITY_BY_WEIGHT = new Map([
     [74, "THROTTLED"],
 ]);
 const HTTP2_UNKNOWN_FRAME_NAMES = new Map([
-    [0x03, "RstStream"],
     [0x05, "PushPromise"],
     [0x06, "Ping"],
     [0x07, "GoAway"],

--- a/src/h2/akamai.rs
+++ b/src/h2/akamai.rs
@@ -71,6 +71,7 @@ fn compute_fingerprint<'a>(frames: impl IntoIterator<Item = &'a Frame>) -> Strin
                     frame.priority.weight
                 );
             }
+            Frame::RstStream(_) => {}
             Frame::PriorityUpdate(_) => {}
             Frame::Headers(frame) => {
                 if headers_count > 0 {

--- a/src/h2/fingerprint.rs
+++ b/src/h2/fingerprint.rs
@@ -43,7 +43,10 @@ impl Http2Fingerprint {
                 }
                 stream_id = Some(headers.stream_id);
             }
-            if !matches!(frame, Frame::Data(_) | Frame::Unknown(_)) {
+            if !matches!(
+                frame,
+                Frame::Data(_) | Frame::RstStream(_) | Frame::Unknown(_)
+            ) {
                 opening_frames.push(frame);
             }
         }
@@ -74,7 +77,7 @@ fn fingerprint_text(frames: &[&Frame], stream_id: u32) -> String {
                     let _ = write!(output, "{id}={value}");
                 }
             }
-            Frame::Settings(_) | Frame::Data(_) | Frame::Unknown(_) => {}
+            Frame::Settings(_) | Frame::Data(_) | Frame::RstStream(_) | Frame::Unknown(_) => {}
             Frame::WindowUpdate(frame) => {
                 push_token(&mut output);
                 push_target(&mut output, "WINDOW_UPDATE", frame.stream_id, stream_id);

--- a/src/h2/frame.rs
+++ b/src/h2/frame.rs
@@ -5,6 +5,7 @@ mod error;
 mod headers;
 mod priority;
 mod priority_update;
+mod rst_stream;
 mod settings;
 mod window_update;
 
@@ -18,6 +19,7 @@ pub use headers::{
 use httlib_hpack::Decoder;
 pub use priority::{PriorityFrame, StreamDependency};
 pub use priority_update::PriorityUpdateFrame;
+pub use rst_stream::{ErrorCode, ErrorCodeName, RstStreamFrame};
 use serde::{de, Deserialize, Deserializer, Serialize};
 pub use settings::{Setting, SettingValue, SettingsFrame};
 pub use window_update::WindowUpdateFrame;
@@ -250,6 +252,8 @@ pub enum Frame {
     WindowUpdate(WindowUpdateFrame),
     /// A legacy PRIORITY frame.
     Priority(PriorityFrame),
+    /// An RST_STREAM frame.
+    RstStream(RstStreamFrame),
     /// An extensible PRIORITY_UPDATE frame.
     PriorityUpdate(PriorityUpdateFrame),
     /// A HEADERS frame, including any CONTINUATION metadata.
@@ -278,8 +282,14 @@ enum FrameRepr {
     /// A candidate PRIORITY frame representation.
     Priority(PriorityFrame),
 
+    /// A candidate RST_STREAM frame representation.
+    RstStream(RstStreamFrame),
+
     /// A candidate PRIORITY_UPDATE frame representation.
     PriorityUpdate(PriorityUpdateFrame),
+
+    /// A legacy RST_STREAM saved before the frame had a dedicated model.
+    LegacyRstStream(LegacyRstStreamFrame),
 
     /// A candidate frame representation without type-specific payload decoding.
     Unknown(UnknownFrame),
@@ -304,9 +314,13 @@ impl<'de> Deserialize<'de> for Frame {
             FrameRepr::Priority(frame) if frame.frame_type == FrameType::Priority => {
                 Self::Priority(frame)
             }
+            FrameRepr::RstStream(frame) if frame.frame_type == FrameType::RstStream => {
+                Self::RstStream(frame)
+            }
             FrameRepr::PriorityUpdate(frame) if frame.frame_type == FrameType::PriorityUpdate => {
                 Self::PriorityUpdate(frame)
             }
+            FrameRepr::LegacyRstStream(frame) => Self::RstStream(frame.0),
             FrameRepr::Unknown(frame) if frame.frame_type == FrameType::Unknown => {
                 Self::Unknown(frame)
             }
@@ -330,6 +344,7 @@ impl Frame {
             Self::Settings(_) => FrameType::Settings,
             Self::WindowUpdate(_) => FrameType::WindowUpdate,
             Self::Priority(_) => FrameType::Priority,
+            Self::RstStream(_) => FrameType::RstStream,
             Self::PriorityUpdate(_) => FrameType::PriorityUpdate,
             Self::Headers(_) => FrameType::Headers,
             Self::Unknown(_) => FrameType::Unknown,
@@ -344,6 +359,7 @@ impl Frame {
             Self::Settings(frame) => frame.stream_id,
             Self::WindowUpdate(frame) => frame.stream_id,
             Self::Priority(frame) => frame.stream_id,
+            Self::RstStream(frame) => frame.stream_id,
             Self::PriorityUpdate(frame) => frame.stream_id,
             Self::Headers(frame) => frame.stream_id,
             Self::Unknown(frame) => frame.stream_id,
@@ -358,6 +374,7 @@ impl Frame {
             Self::Settings(frame) => frame.length,
             Self::WindowUpdate(frame) => frame.length,
             Self::Priority(frame) => frame.length,
+            Self::RstStream(frame) => frame.length,
             Self::PriorityUpdate(frame) => frame.length,
             Self::Headers(frame) => frame.length,
             Self::Unknown(frame) => frame.length,
@@ -385,6 +402,9 @@ pub enum FrameType {
 
     /// PRIORITY (`0x02`).
     Priority,
+
+    /// RST_STREAM (`0x03`).
+    RstStream,
 
     /// PRIORITY_UPDATE (`0x10`).
     PriorityUpdate,
@@ -421,6 +441,33 @@ pub struct UnknownFrame {
     pub payload: Vec<u8>,
 }
 
+/// Legacy serialized RST_STREAM representation retained for saved captures.
+#[derive(Deserialize)]
+#[serde(try_from = "LegacyRstStreamFrameRepr")]
+struct LegacyRstStreamFrame(RstStreamFrame);
+
+/// Fields emitted before RST_STREAM received a dedicated frame model.
+#[derive(Deserialize)]
+struct LegacyRstStreamFrameRepr {
+    /// Saved generic frame category.
+    frame_type: FrameType,
+
+    /// Original HTTP/2 frame type.
+    type_id: u8,
+
+    /// Stream terminated by the frame.
+    stream_id: u32,
+
+    /// Saved payload length.
+    length: usize,
+
+    /// Original unused flag byte.
+    flags: u8,
+
+    /// Four-byte HTTP/2 error code.
+    payload: Vec<u8>,
+}
+
 /// Deserialization shape used to validate a frame retained as unknown.
 #[derive(Deserialize)]
 struct UnknownFrameRepr {
@@ -450,7 +497,7 @@ impl TryFrom<UnknownFrameRepr> for UnknownFrame {
         if repr.frame_type != FrameType::Unknown {
             return Err("unknown frame_type must be Unknown");
         }
-        if matches!(repr.type_id, 0x0 | 0x1 | 0x2 | 0x4 | 0x8 | 0x9 | 0x10) {
+        if matches!(repr.type_id, 0x0 | 0x1 | 0x2 | 0x3 | 0x4 | 0x8 | 0x9 | 0x10) {
             return Err("a supported HTTP/2 frame type cannot use UnknownFrame");
         }
         if repr.stream_id > 0x7fff_ffff {
@@ -474,6 +521,23 @@ impl TryFrom<UnknownFrameRepr> for UnknownFrame {
     }
 }
 
+impl TryFrom<LegacyRstStreamFrameRepr> for LegacyRstStreamFrame {
+    type Error = &'static str;
+
+    fn try_from(repr: LegacyRstStreamFrameRepr) -> Result<Self, Self::Error> {
+        if repr.frame_type != FrameType::Unknown || repr.type_id != 0x03 {
+            return Err("legacy RST_STREAM must use Unknown frame type 0x03");
+        }
+        if repr.length != repr.payload.len() {
+            return Err("legacy RST_STREAM length does not match its payload");
+        }
+
+        RstStreamFrame::try_from((repr.flags, repr.stream_id, repr.payload.as_slice()))
+            .map(Self)
+            .map_err(|_| "legacy RST_STREAM fields are invalid")
+    }
+}
+
 impl TryFrom<(u8, u8, u32, &[u8])> for Frame {
     type Error = FrameError;
 
@@ -484,6 +548,7 @@ impl TryFrom<(u8, u8, u32, &[u8])> for Frame {
             0x0 => DataFrame::try_from((flags, stream_id, payload)).map(Frame::Data),
             0x1 => HeadersFrame::try_from((flags, stream_id, payload)).map(Frame::Headers),
             0x2 => PriorityFrame::try_from((stream_id, payload)).map(Frame::Priority),
+            0x3 => RstStreamFrame::try_from((flags, stream_id, payload)).map(Frame::RstStream),
             0x4 => SettingsFrame::try_from((flags, stream_id, payload)).map(Frame::Settings),
             0x8 => WindowUpdateFrame::try_from((stream_id, payload)).map(Frame::WindowUpdate),
             0x10 => PriorityUpdateFrame::try_from((flags, stream_id, payload))
@@ -609,7 +674,7 @@ mod tests {
     }
 
     #[test]
-    fn unknown_frame_deserialization_rejects_supported_types_and_bad_lengths() {
+    fn unknown_frame_deserialization_rejects_supported_types_and_accepts_legacy_rst_stream() {
         let supported_type = r#"{
             "frame_type":"Unknown",
             "type_id":1,
@@ -626,8 +691,20 @@ mod tests {
             "flags":0,
             "payload":[0]
         }"#;
+        let legacy_rst_stream = r#"{
+            "frame_type":"Unknown",
+            "type_id":3,
+            "stream_id":5,
+            "length":4,
+            "flags":0,
+            "payload":[0,0,0,8]
+        }"#;
 
         assert!(serde_json::from_str::<UnknownFrame>(supported_type).is_err());
         assert!(serde_json::from_str::<UnknownFrame>(bad_length).is_err());
+        assert!(matches!(
+            serde_json::from_str::<Frame>(legacy_rst_stream).unwrap(),
+            Frame::RstStream(frame) if frame.error_code.id == 8
+        ));
     }
 }

--- a/src/h2/frame/rst_stream.rs
+++ b/src/h2/frame/rst_stream.rs
@@ -1,0 +1,243 @@
+//! HTTP/2 RST_STREAM frame and error-code decoding.
+
+use serde::{Deserialize, Serialize};
+
+use super::{FrameError, FrameType};
+
+const RST_STREAM_PAYLOAD_LENGTH: usize = 4;
+
+/// A decoded HTTP/2 `RST_STREAM` frame.
+///
+/// `RST_STREAM` terminates one stream without closing the HTTP/2 connection. See
+/// [RFC 9113, Section 6.4](https://www.rfc-editor.org/rfc/rfc9113#section-6.4).
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "RstStreamFrameRepr")]
+pub struct RstStreamFrame {
+    /// The frame category, always [`FrameType::RstStream`].
+    pub frame_type: FrameType,
+
+    /// Nonzero stream identifier terminated by this frame.
+    pub stream_id: u32,
+
+    /// Payload length, always four bytes.
+    pub length: usize,
+
+    /// Original unused flag byte retained for wire analysis.
+    pub flags: u8,
+
+    /// Reason the endpoint terminated the stream.
+    pub error_code: ErrorCode,
+}
+
+/// An HTTP/2 connection or stream error code.
+///
+/// The numeric value is retained alongside its registered meaning so unknown future codes remain
+/// representable. See [RFC 9113, Section 7](https://www.rfc-editor.org/rfc/rfc9113#section-7).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "ErrorCodeRepr")]
+pub struct ErrorCode {
+    /// Original 32-bit error code from the wire.
+    pub id: u32,
+
+    /// Registered or unrecognized meaning of the code.
+    pub name: ErrorCodeName,
+}
+
+registry_enum! {
+    /// Semantic name of an HTTP/2 error code.
+    #[serde(rename_all = "PascalCase")]
+    #[non_exhaustive]
+    pub enum ErrorCodeName: u32 {
+        /// Graceful completion without an error (`0x00`).
+        NoError => 0x00,
+
+        /// A generic protocol violation (`0x01`).
+        ProtocolError => 0x01,
+
+        /// An unexpected internal failure (`0x02`).
+        InternalError => 0x02,
+
+        /// A flow-control violation (`0x03`).
+        FlowControlError => 0x03,
+
+        /// SETTINGS acknowledgement was not received in time (`0x04`).
+        SettingsTimeout => 0x04,
+
+        /// A frame was received after the stream was half-closed (`0x05`).
+        StreamClosed => 0x05,
+
+        /// A frame had an invalid size (`0x06`).
+        FrameSizeError => 0x06,
+
+        /// The stream was refused before application processing (`0x07`).
+        RefusedStream => 0x07,
+
+        /// The stream is no longer needed (`0x08`).
+        Cancel => 0x08,
+
+        /// The endpoint could not maintain the HPACK context (`0x09`).
+        CompressionError => 0x09,
+
+        /// A CONNECT tunnel was reset or closed abnormally (`0x0a`).
+        ConnectError => 0x0a,
+
+        /// The endpoint asks its peer to reduce its load (`0x0b`).
+        EnhanceYourCalm => 0x0b,
+
+        /// The negotiated security properties are insufficient (`0x0c`).
+        InadequateSecurity => 0x0c,
+
+        /// The endpoint requires HTTP/1.1 (`0x0d`).
+        Http11Required => 0x0d,
+    }
+
+    fallback(_id) {
+        /// An unregistered or unsupported error code.
+        Other,
+    } => Self::Other;
+}
+
+/// Deserialization shape validated before constructing [`RstStreamFrame`].
+#[derive(Deserialize)]
+struct RstStreamFrameRepr {
+    /// Saved frame category.
+    frame_type: FrameType,
+
+    /// Saved stream identifier.
+    stream_id: u32,
+
+    /// Saved payload length.
+    length: usize,
+
+    /// Saved unused flag byte.
+    flags: u8,
+
+    /// Saved stream error code.
+    error_code: ErrorCode,
+}
+
+/// Deserialization shape used to validate an [`ErrorCode`] name against its numeric value.
+#[derive(Deserialize)]
+struct ErrorCodeRepr {
+    /// Saved numeric error code.
+    id: u32,
+
+    /// Saved semantic name.
+    name: ErrorCodeName,
+}
+
+impl From<u32> for ErrorCode {
+    fn from(id: u32) -> Self {
+        Self {
+            id,
+            name: ErrorCodeName::from(id),
+        }
+    }
+}
+
+impl TryFrom<ErrorCodeRepr> for ErrorCode {
+    type Error = &'static str;
+
+    fn try_from(repr: ErrorCodeRepr) -> Result<Self, Self::Error> {
+        if repr.name != ErrorCodeName::from(repr.id) {
+            return Err("HTTP/2 error code name does not match its identifier");
+        }
+
+        Ok(Self {
+            id: repr.id,
+            name: repr.name,
+        })
+    }
+}
+
+impl TryFrom<RstStreamFrameRepr> for RstStreamFrame {
+    type Error = &'static str;
+
+    fn try_from(repr: RstStreamFrameRepr) -> Result<Self, Self::Error> {
+        if repr.frame_type != FrameType::RstStream {
+            return Err("RST_STREAM frame_type must be RstStream");
+        }
+        if repr.stream_id == 0 || repr.stream_id > 0x7fff_ffff {
+            return Err("RST_STREAM stream_id must be a nonzero 31-bit value");
+        }
+        if repr.length != RST_STREAM_PAYLOAD_LENGTH {
+            return Err("RST_STREAM payload length must be four");
+        }
+
+        Ok(Self {
+            frame_type: repr.frame_type,
+            stream_id: repr.stream_id,
+            length: repr.length,
+            flags: repr.flags,
+            error_code: repr.error_code,
+        })
+    }
+}
+
+impl TryFrom<(u8, u32, &[u8])> for RstStreamFrame {
+    type Error = FrameError;
+
+    fn try_from((flags, stream_id, payload): (u8, u32, &[u8])) -> Result<Self, Self::Error> {
+        if stream_id == 0 || stream_id > 0x7fff_ffff {
+            return Err(FrameError::InvalidStreamId);
+        }
+        let payload: [u8; RST_STREAM_PAYLOAD_LENGTH] =
+            payload.try_into().map_err(|_| FrameError::BadFrameSize)?;
+
+        Ok(Self {
+            frame_type: FrameType::RstStream,
+            stream_id,
+            length: payload.len(),
+            flags,
+            error_code: u32::from_be_bytes(payload).into(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{ErrorCodeName, RstStreamFrame};
+    use crate::h2::frame::{Frame, FrameError, FrameParser};
+
+    #[test]
+    fn rst_stream_decodes_cancel_and_enforces_its_wire_shape() {
+        let wire = [0, 0, 4, 0x03, 0xa5, 0, 0, 0, 5, 0, 0, 0, 8];
+        let Some(Frame::RstStream(frame)) =
+            FrameParser::default().parse(&wire).unwrap().into_frame()
+        else {
+            panic!("expected an RST_STREAM frame");
+        };
+
+        assert_eq!(frame.stream_id, 5);
+        assert_eq!(frame.flags, 0xa5);
+        assert_eq!(frame.error_code.id, 8);
+        assert_eq!(frame.error_code.name, ErrorCodeName::Cancel);
+
+        let json = serde_json::to_value(&frame).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "frame_type": "RstStream",
+                "stream_id": 5,
+                "length": 4,
+                "flags": 165,
+                "error_code": {"id": 8, "name": "Cancel"}
+            })
+        );
+        assert_eq!(
+            serde_json::from_value::<RstStreamFrame>(json).unwrap(),
+            frame
+        );
+
+        assert_eq!(
+            RstStreamFrame::try_from((0, 0, &[0; 4][..])).unwrap_err(),
+            FrameError::InvalidStreamId
+        );
+        assert_eq!(
+            RstStreamFrame::try_from((0, 1, &[0; 3][..])).unwrap_err(),
+            FrameError::BadFrameSize
+        );
+    }
+}


### PR DESCRIPTION
Decode HTTP/2 `RST_STREAM` frames so a captured type 0x03 with payload `00 00 00 08` appears as RstStream with error_code { id: 8, name: "Cancel" } in JSON and the WebUI.
